### PR TITLE
fix: Use REDIS_PASSWORD environment variable for Redis password

### DIFF
--- a/config/redis.go
+++ b/config/redis.go
@@ -10,7 +10,7 @@ import (
 func InitRedis() *redis.Client {
 	client := redis.NewClient(&redis.Options{
 		Addr:     os.Getenv("REDIS"),
-		Password: "",
+		Password: os.Getenv("REDIS_PASSWORD"),
 		DB:       0,
 	})
 


### PR DESCRIPTION
This commit updates the Redis configuration to use the `REDIS_PASSWORD` environment variable for setting the Redis password. This allows for more secure and flexible password management.